### PR TITLE
Fix missing dependency on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ package main
     
 import (
 	"fmt"
+	"time"
     
 	. "github.com/kkdai/pubsub"
 )


### PR DESCRIPTION
I got this error when using code from readme:

```
# command-line-arguments
./main.go:40:9: undefined: time
```